### PR TITLE
Adds requests in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ passlib
 pyalsaaudio >= 0.8
 flask-table
 isodate
+requests >= 2.27


### PR DESCRIPTION
`requests` wasn't present in the requirements, causing an error if not installed otherwise.